### PR TITLE
Base line .htaccess template reformat and mod_alias matching fixes

### DIFF
--- a/configs/silverstripe/htaccess.sample
+++ b/configs/silverstripe/htaccess.sample
@@ -6,8 +6,8 @@ Allow from 127.0.0.1
 </Files>
 
 <Files web.config>
-	Order deny,allow
-	Deny from all
+    Order deny,allow
+    Deny from all
 </Files>
 
 ErrorDocument 404 /assets/error-404.html
@@ -17,67 +17,57 @@ Header always append X-Frame-Options SAMEORIGIN
 Header set X-Content-Type-Options "nosniff"
 
 <IfModule mod_expires.c>
-# Disable Etags as they may mess with multiple servers
-Header unset ETag
-FileETag None
+    # Disable Etags as they may mess with multiple servers
+    Header unset ETag
+    FileETag None
 
-# Turn on Expires and set default to 0
-	ExpiresActive On
-	ExpiresDefault A0
+    # Turn on Expires and set default to 0
+    ExpiresActive On
+    ExpiresDefault A0
  
-# Set up caching on media files for 1 year (forever?)
-	<FilesMatch "\.(flv|ico|pdf|avi|mov|ppt|doc|mp3|wmv|wav)$">
-          ExpiresDefault A29030400
-	  Header append Cache-Control "public"
-	</FilesMatch>
+    # Set up caching on media files for 1 year (forever?)
+    <FilesMatch "\.(flv|ico|pdf|avi|mov|ppt|doc|mp3|wmv|wav)$">
+        ExpiresDefault A29030400
+        Header append Cache-Control "public"
+    </FilesMatch>
  
-# Set up caching on media files for 1 week
-	<FilesMatch "\.(gif|jpg|jpeg|png|swf)$">
-	  ExpiresDefault A604800
-	  Header append Cache-Control "public"
-	</FilesMatch>
+    # Set up caching on media files for 1 week
+    <FilesMatch "\.(gif|jpg|jpeg|png|swf)$">
+        ExpiresDefault A604800
+        Header append Cache-Control "public"
+    </FilesMatch>
  
-# Set up 2 Hour caching on commonly updated files
-	<FilesMatch "\.(xml|txt|html|js|css)$">
-	  ExpiresDefault A604800
-	  Header append Cache-Control "proxy-revalidate"
-	</FilesMatch>
+    # Set up 2 Hour caching on commonly updated files
+    <FilesMatch "\.(xml|txt|html|js|css)$">
+        ExpiresDefault A604800
+        Header append Cache-Control "proxy-revalidate"
+    </FilesMatch>
 
-<FilesMatch "\.(htc)$">
-  ForceType text/x-component
-</FilesMatch>
-
-# The below has been changed!! We don't have these settings as 
-# we leave it to the PHP files themselves to determine cache settings, so that
-# the if-mod-since headers are still sent by clients and the PHP files can determine
-# how to respond (ie with a 304 if desired)
-# Force no caching for dynamic files
-#	<FilesMatch "\.(php|cgi|pl|htm)$">
-#	  ExpiresActive Off
-#	  Header set Cache-Control "private, no-cache, no-store, proxy-revalidate, no-transform"
-#	  Header set Pragma "no-cache"
-#	</FilesMatch>
+    <FilesMatch "\.(htc)$">
+        ForceType text/x-component
+    </FilesMatch>
 </IfModule>
 
 <IfModule mod_deflate.c>
-	# IE fixes surprise surprise
-	 SetOutputFilter DEFLATE
-	 SetEnvIfNoCase Request_URI  \.(?:gif|jpe?g|png)$ no-gzip dont-vary
-	 SetEnvIfNoCase Request_URI  \.(?:exe|t?gz|zip|gz2|sit|rar)$ no-gzip dont-vary
+    # IE fixes surprise surprise
+    SetOutputFilter DEFLATE
+    SetEnvIfNoCase Request_URI \.(?:gif|jpe?g|png)$ no-gzip dont-vary
+    SetEnvIfNoCase Request_URI \.(?:exe|t?gz|zip|gz2|sit|rar)$ no-gzip dont-vary
 </IfModule>
 
-
 <IfModule mod_alias.c>
-	RedirectMatch 403 /silverstripe-cache(/|$)
+    RedirectMatch 403 ^/silverstripe-cache(/|$)
+    RedirectMatch 403 ^/vendor(/|$)
+    RedirectMatch 403 ^/composer\.(json|lock)
 </IfModule>
 
 <IfModule mod_rewrite.c>
-	SetEnv HTTP_MOD_REWRITE On
-	RewriteEngine On
-	# RewriteBase ${rewrite.base}
-	
-	RewriteCond %{REQUEST_URI} ^(.*)$
-	RewriteCond %{REQUEST_FILENAME} !-f
-	RewriteRule .* framework/main.php?url=%1&%{QUERY_STRING} [L]
+    SetEnv HTTP_MOD_REWRITE On
+    RewriteEngine On
+    # RewriteBase ${rewrite.base}
+
+    RewriteCond %{REQUEST_URI} ^(.*)$
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteRule .* framework/main.php?url=%1&%{QUERY_STRING} [L]
 </IfModule>
 ### SILVERSTRIPE END ###


### PR DESCRIPTION
Main fix is the regex in the mod_alias checks was catching too many URLs.