### PR TITLE
Removing reference to a file called VERSION

### DIFF
--- a/buildfile.xml
+++ b/buildfile.xml
@@ -34,8 +34,6 @@
 
 	<property file="${project.basedir}/build/build.properties"></property>
 
-	<php expression="trim(file_get_contents('${module.name}/VERSION'))" returnProperty="module.version" />
-
 	<if>
 		<isset property="env.GIT_COMMIT" />
 		<then>


### PR DESCRIPTION
Can we do away with this call during phing? I don't think I've ever seen any one use it and it just spams logs during build outputs.