### PR TITLE
Improvements to patch management

### DIFF
--- a/buildfile.xml
+++ b/buildfile.xml
@@ -278,6 +278,20 @@ putenv('APACHE_RUN_USER=deploy');
 	<target name="apply_patches">
 		<mkdir dir="${patches.dir}" />
 		<sspatches patchdir="${patches.dir}" />
+		<if>
+			<isset property="check_patches" />
+			<then>
+				<if>
+					<isset property="patches_applied" />
+					<then>
+						<fail>Patches already applied - this needs fixing</fail>
+					</then>
+					<else>
+						<echo message="Patches successful" />
+					</else>
+				</if>
+			</then>
+		</if>
 	</target>
 	
 


### PR DESCRIPTION
Add phing property "check_patches" for Jenkins to call.
Failing patches or already applied patches will fail builds if check_patches is defined.
The ApplyPatchesTask Task now fails if a patch fails and identifies if a patch is already applied.