### PR TITLE
Patch management improvements

### DIFF
--- a/buildfile.xml
+++ b/buildfile.xml
@@ -278,6 +278,20 @@ putenv('APACHE_RUN_USER=deploy');
 	<target name="apply_patches">
 		<mkdir dir="${patches.dir}" />
 		<sspatches patchdir="${patches.dir}" />
+		<if>
+			<isset property="check_patches" />
+			<then>
+				<if>
+					<isset property="patches_applied" />
+					<then>
+						<fail>Patches already applied - this needs fixing</fail>
+					</then>
+					<else>
+						<echo message="Patches successful" />
+					</else>
+				</if>
+			</then>
+		</if>
 	</target>
 	
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.5.x-dev"
+			"dev-master": "2.0.x-dev"
 		}
 	}
 }


### PR DESCRIPTION
Add phing property "check_patches" for Jenkins to call.
Failing patches or already applied patches will fail builds if check_patches is defined.
The ApplyPatchesTask Task now fails if a patch fails and identifies if a patch is already applied.
Bump version to 2.x as this is a breaking change.