### PR TITLE
feat(formatWithColor): Add ability to use ANSI color functionality

### DIFF
--- a/ApplyPatchesTask.php
+++ b/ApplyPatchesTask.php
@@ -1,6 +1,8 @@
 <?php
 /* All code covered by the BSD license located at http://silverstripe.org/bsd-license/ */
 
+include_once dirname(__FILE__).'/SilverStripeBuildTask.php';
+
 /**
  * Task for applying patch files from a folder to a source trunk
  *
@@ -8,7 +10,7 @@
  *
  * @author Marcus Nyeholt <marcus@silverstripe.com.au>
  */
-class ApplyPatchesTask extends Task {
+class ApplyPatchesTask extends SilverStripeBuildTask {
     private $patchDir;
 
 	public function setPatchDir($v) {
@@ -47,7 +49,7 @@ class ApplyPatchesTask extends Task {
 					$this->log(implode("\n", $exec_output) . "\n\n");
 
 					if ($exec_return) {
-						throw new Exception("The patch produced errors");
+						throw new Exception($this->formatWithColor("fg-white, bg-red", "The patch produced errors"));
 					}
 				} else {
 					$this->log("This patch is already applied - skipping\n", Project::MSG_WARN);

--- a/SilverStripeBuildTask.php
+++ b/SilverStripeBuildTask.php
@@ -10,7 +10,31 @@ All code covered by the BSD license located at http://silverstripe.org/bsd-licen
  * @author marcus
  */
 abstract class SilverStripeBuildTask extends Task {
-    protected $cleanupEnv = false;
+	/**
+	 * @see formatWithColor()
+	 * @var array
+	 */
+	private static $ansiCodes = array(
+		'bold'       => 1,
+		'fg-black'   => 30,
+		'fg-red'     => 31,
+		'fg-green'   => 32,
+		'fg-yellow'  => 33,
+		'fg-blue'    => 34,
+		'fg-magenta' => 35,
+		'fg-cyan'    => 36,
+		'fg-white'   => 37,
+		'bg-black'   => 40,
+		'bg-red'     => 41,
+		'bg-green'   => 42,
+		'bg-yellow'  => 43,
+		'bg-blue'    => 44,
+		'bg-magenta' => 45,
+		'bg-cyan'    => 46,
+		'bg-white'   => 47
+	);
+
+	protected $cleanupEnv = false;
 	
 	protected function configureEnvFile() {
 		// fake the _ss_environment.php file for the moment
@@ -58,10 +82,10 @@ TEXT;
 	protected function getInput($prompt) {
 		require_once 'phing/input/InputRequest.php';
 		$request = new InputRequest($prompt);
-        $request->setPromptChar(':');
-        
-        $this->project->getInputHandler()->handleInput($request);
-        $value = $request->getInput();
+		$request->setPromptChar(':');
+		
+		$this->project->getInputHandler()->handleInput($request);
+		$value = $request->getInput();
 		return $value;
 	}
 
@@ -79,5 +103,39 @@ TEXT;
 		}
 		
 		return $ret;
+	}
+
+	/**
+	 * Formats a buffer with a specified ANSI color sequence if colors are
+	 * enabled. (Taken from PHPUnit)
+	 *
+	 * eg. 	$this->formatWithColor("fg-white, bg-red", "ERROR")
+	 *		$this->formatWithColor("fg-black, bg-green", "SUCCESS");
+	 *
+	 * @param string $color
+	 * @param string $buffer
+	 *
+	 * @return string
+	 */
+	protected function formatWithColor($color, $buffer)
+	{
+		$codes   = array_map('trim', explode(',', $color));
+		$lines   = explode("\n", $buffer);
+		$padding = max(array_map('strlen', $lines));
+		$styles  = array();
+
+		foreach ($codes as $code) {
+			$styles[] = self::$ansiCodes[$code];
+		}
+
+		$style = sprintf("\x1b[%sm", implode(';', $styles));
+
+		$styledLines = array();
+
+		foreach ($lines as $line) {
+			$styledLines[] = $style . str_pad($line, $padding) . "\x1b[0m";
+		}
+
+		return implode("\n", $styledLines);
 	}
 }


### PR DESCRIPTION
feat(formatWithColor): Add ability to use ANSI color functionality from PHPUnit. (ie. highlight text in GREEN or RED when a task succeeds or fails)

This will make scanning for failures/issues easier in Phing and Jenkins.

![error-color](https://cloud.githubusercontent.com/assets/3859574/24734165/45b5b640-1abf-11e7-95c7-52d27df9d0dc.png)

Ugly in Windows console:
![windows](https://cloud.githubusercontent.com/assets/3859574/24734481/fa48eab8-1ac0-11e7-869e-7fb048c63113.png)

